### PR TITLE
Address inode creation race in fakelib filesystem

### DIFF
--- a/library/library_test.go
+++ b/library/library_test.go
@@ -202,66 +202,66 @@ func TestLetterName(t *testing.T) {
 }
 
 func TestCustomTagger(t *testing.T) {
-    want := trackInfo{
-        Artist: "Custom Artist",
-        Album: "Custom Album",
-        Title: "Custom Title",
-    }
+	want := trackInfo{
+		Artist: "Custom Artist",
+		Album:  "Custom Album",
+		Title:  "Custom Title",
+	}
 
-    tagF := func(idx int) *id3v2.Tag {
-        t := id3v2.NewEmptyTag()
-        t.SetArtist(want.Artist)
-        t.SetAlbum(want.Album)
-        t.SetTitle(want.Title)
-        return t
-    }
+	tagF := func(idx int) *id3v2.Tag {
+		t := id3v2.NewEmptyTag()
+		t.SetArtist(want.Artist)
+		t.SetAlbum(want.Album)
+		t.SetTitle(want.Title)
+		return t
+	}
 
-    lib, err := New(bytes.NewReader(nil))
-    if err != nil {
-        t.Fatalf("Failed to create new library: %v", err)
-    }
-    lib.Tagger = tagF
+	lib, err := New(bytes.NewReader(nil))
+	if err != nil {
+		t.Fatalf("Failed to create new library: %v", err)
+	}
+	lib.Tagger = tagF
 
-    gotSong, err := lib.SongAt(0) 
-    if err != nil {
-        t.Fatalf("lib.SongAt(0) = %v", err)
-    }
-    got, err := songInfo(gotSong)
-    if err != nil {
-        t.Fatalf("songInfo(...) = _, %v, want _, nil", err)
-    }
+	gotSong, err := lib.SongAt(0)
+	if err != nil {
+		t.Fatalf("lib.SongAt(0) = %v", err)
+	}
+	got, err := songInfo(gotSong)
+	if err != nil {
+		t.Fatalf("songInfo(...) = _, %v, want _, nil", err)
+	}
 
-    if diff := cmp.Diff(want, got); diff != "" {
-        t.Errorf("lib.SongAt(0) had unexpected diff (want -> got):\n%s", diff)
-    }
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("lib.SongAt(0) had unexpected diff (want -> got):\n%s", diff)
+	}
 }
 
 func TestCustomPather(t *testing.T) {
-    wantTag := id3v2.NewEmptyTag()
-    const want = "abc.mp3" 
+	wantTag := id3v2.NewEmptyTag()
+	const want = "abc.mp3"
 
-    lib, err := New(bytes.NewReader(nil))
-    if err != nil {
-        t.Fatalf("Failed to create new library: %v", err)
-    }
-    lib.Tagger = func(int) *id3v2.Tag {
-        return wantTag 
-    }
-    lib.Pather = func(_ int, gotTag *id3v2.Tag) string {
-        // Need to make sure that the pather is passed the tag from the
-        // tagger.
-        if wantTag != gotTag {
-            t.Errorf("Pather got unexpected tag %v, want %v", gotTag, wantTag)
-        }
-        return want
-    }
+	lib, err := New(bytes.NewReader(nil))
+	if err != nil {
+		t.Fatalf("Failed to create new library: %v", err)
+	}
+	lib.Tagger = func(int) *id3v2.Tag {
+		return wantTag
+	}
+	lib.Pather = func(_ int, gotTag *id3v2.Tag) string {
+		// Need to make sure that the pather is passed the tag from the
+		// tagger.
+		if wantTag != gotTag {
+			t.Errorf("Pather got unexpected tag %v, want %v", gotTag, wantTag)
+		}
+		return want
+	}
 
-    got, err := lib.PathAt(0)
-    if err != nil {
-        t.Fatalf("lib.PathAt(0) = _, %v; want _, nil", err)
-    }
+	got, err := lib.PathAt(0)
+	if err != nil {
+		t.Fatalf("lib.PathAt(0) = _, %v; want _, nil", err)
+	}
 
-    if got != want {
-        t.Errorf("lib.PathAt(0) = %q, want %q", got, want)
-    }
+	if got != want {
+		t.Errorf("lib.PathAt(0) = %q, want %q", got, want)
+	}
 }


### PR DESCRIPTION
Inodes were not updated atomically which could potentially lead to race.

Also fixes an issue in `filesystem_test` where Go was walking files more than once.